### PR TITLE
📝 use README.md for the crates.io documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ documentation = "https://docs.rs/serial-line-ip"
 description = """
 Serial Line Internet Protocol (SLIP) API.
 """
+readme = "README.md"


### PR DESCRIPTION
Setting the [package].readme to README.md will populate the
documentation for crates.io.

Fixes #2 .