### PR TITLE
🛡 reduce max age for crates.io shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.com/mvertescher/serial-line-ip-rs.svg?branch=master)](https://travis-ci.com/mvertescher/serial-line-ip-rs)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Crates.io - serial-line-ip](https://img.shields.io/crates/v/serial-line-ip.svg?maxAge=2592000)](https://crates.io/crates/serial-line-ip)
+[![Crates.io - serial-line-ip](https://img.shields.io/crates/v/serial-line-ip.svg)](https://crates.io/crates/serial-line-ip)
 [![Released API docs](https://docs.rs/serial-line-ip/badge.svg)](https://docs.rs/serial-line-ip)
 
 Serial Line Internet Protocol (SLIP) implementation.


### PR DESCRIPTION
Github's external resource caching is informed by the cache-control
header when fetching the resources, see:
> https://github.com/github/markup/issues/224

Remove the explicit max-age setting on the crates.io badge.

Tested:
```bash
 # default max-age is 300 seconds
curl -v https://img.shields.io/crates/v/serial-line-ip.svg 2>&1 | rg cache-control -i
< cache-control: max-age=300
```