### PR TITLE
Name `EncodeTotals` fields and make it public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,15 +33,15 @@
 //!
 //! let mut totals = slip.encode(INPUT_1, &mut output).unwrap();
 //! let expected_bytes_written = 1 + INPUT_1.len();
-//! assert_eq!(expected_bytes_written, totals.1);
+//! assert_eq!(expected_bytes_written, totals.written);
 //!
-//! totals += slip.encode(INPUT_2, &mut output[totals.1..]).unwrap();
+//! totals += slip.encode(INPUT_2, &mut output[totals.written..]).unwrap();
 //! let expected_bytes_written = expected_bytes_written + INPUT_2.len();
-//! assert_eq!(expected_bytes_written, totals.1);
+//! assert_eq!(expected_bytes_written, totals.written);
 //!
-//! totals += slip.finish(&mut output[totals.1..]).unwrap();
-//! assert_eq!(expected_bytes_written + 1, totals.1);
-//! assert_eq!(EXPECTED, &output[..totals.1]);
+//! totals += slip.finish(&mut output[totals.written..]).unwrap();
+//! assert_eq!(expected_bytes_written + 1, totals.written);
+//! assert_eq!(EXPECTED, &output[..totals.written]);
 //! ```
 //!
 //! ### Decoding

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,9 +80,9 @@ mod decoder;
 mod encoder;
 mod error;
 
-pub use error::{Error, Result};
 pub use decoder::Decoder;
-pub use encoder::Encoder;
+pub use encoder::{EncodeTotals, Encoder};
+pub use error::{Error, Result};
 
 /// Frame end
 const END: u8 = 0xC0;


### PR DESCRIPTION
It's part of the public API, so it probably makes sense to reexport this type